### PR TITLE
Enable announcements and convert emojis to images

### DIFF
--- a/pyconcz_2018/settings/base.py
+++ b/pyconcz_2018/settings/base.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'pyconcz_2018.programme',
 
     'widget_tweaks',
+    'emojificate',
 ]
 
 MIDDLEWARE = [

--- a/pyconcz_2018/templates/old/intermission/annoucements.html
+++ b/pyconcz_2018/templates/old/intermission/annoucements.html
@@ -1,14 +1,17 @@
 {% load formatting %}
+{% load emojificate %}
 
 <h1>Attention!</h1>
 {% for one in announcements %}
 <div class="ann">
-	<div class="ann-content">{{ one.message|markdown }}</div>
+	<div class="ann-content">{{ one.message|markdown|emojificate }}</div>
     <!-- <p><small>{{ one.date_created }}</small></p> -->
 </div>
 {% endfor %}
 <div class="ann">
     <div class="ann-content">
+        {% emojified %}
         Ask speakers at <strong>slido.com</strong> with hashtag <strong>#pyconcz</strong> 💬
+        {% endemojified %}
     </div>
 </div>

--- a/pyconcz_2018/urls.py
+++ b/pyconcz_2018/urls.py
@@ -14,7 +14,7 @@ prefixed_urlpatterns = [
     url(r'^about/team/', include('pyconcz_2018.team.urls')),
     url(r'^programme/', include('pyconcz_2018.programme.urls')),
     url(r'^sponsors/', include('pyconcz_2018.sponsors.urls')),
-    #url(r'^intermission/', include('pyconcz_2018.intermission.urls', namespace='intermission')),
+    url(r'^intermission/', include('pyconcz_2018.intermission.urls', namespace='intermission')),
 
     # static pages
     url(r'^proposals/$',

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pillow~=3.4.1
 pyt==0.7.26
 django-import-export~=0.5.1
 django-widget-tweaks~=1.4.1
+emojificate~=0.2.0


### PR DESCRIPTION
Zatím jsem to nijak nestyloval. Vlastně nevím, kam se ztratily styly z loňska, ale neřeším to teď. Nejspíš mi s tím bude muset pomoct @benabraham a nějak mě nasměrovat (pokud to nechce dělat sám).

Aspoň jsem udělal ty emojis, který dělaly vloni problém, nebylo to konzistentní mezi počítači a nebylo jasný, co se vlastně zobrazí. Výsledek:

---------

<img width="572" alt="image" src="https://user-images.githubusercontent.com/283441/40199181-f7c268bc-5a18-11e8-852e-1f91c41e729b.png">

---------

<img width="702" alt="image" src="https://user-images.githubusercontent.com/283441/40199168-ef66c956-5a18-11e8-83e3-168a4a3e98f8.png">

---------

Jasně, ty Twitter emojis nejsou zrovna nejpěknější a občas vůbec nejde poznat co to je, ale lepší než nic. Jiný k dispozici teď nějak snadno nejsou - viz https://github.com/glasnt/emojificate/issues/4
